### PR TITLE
Update attribute public_ip_requiered description. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* Update attribute public_ip_requiered description
 
 ---
+
 
 ## 1.0.2 (2021-06-14)
 * Upgrade to v0.10.3 of the Civo Terraform Provider

--- a/provider/cmd/pulumi-resource-civo/schema.json
+++ b/provider/cmd/pulumi-resource-civo/schema.json
@@ -1907,7 +1907,7 @@
                 },
                 "publicIpRequired": {
                     "type": "string",
-                    "description": "This should be either false, true or `move_ip_from:intances_id`.\n"
+                    "description": "This should be either `create`, `none` or `move_ip_from:intances_id`.\n"
                 },
                 "ramMb": {
                     "type": "integer",
@@ -1993,7 +1993,7 @@
                 },
                 "publicIpRequired": {
                     "type": "string",
-                    "description": "This should be either false, true or `move_ip_from:intances_id`.\n"
+                    "description": "This should be either `create`, `none` or `move_ip_from:intances_id`.\n"
                 },
                 "region": {
                     "type": "string",
@@ -2083,7 +2083,7 @@
                     },
                     "publicIpRequired": {
                         "type": "string",
-                        "description": "This should be either false, true or `move_ip_from:intances_id`.\n"
+                        "description": "This should be either `create`, `none` or `move_ip_from:intances_id`.\n"
                     },
                     "ramMb": {
                         "type": "integer",

--- a/sdk/dotnet/Instance.cs
+++ b/sdk/dotnet/Instance.cs
@@ -97,7 +97,7 @@ namespace Pulumi.Civo
         public Output<string> PublicIp { get; private set; } = null!;
 
         /// <summary>
-        /// This should be either false, true or `move_ip_from:intances_id`.
+        /// This should be either `create`, `none` or `move_ip_from:intances_id`.
         /// </summary>
         [Output("publicIpRequired")]
         public Output<string?> PublicIpRequired { get; private set; } = null!;
@@ -239,7 +239,7 @@ namespace Pulumi.Civo
         public Input<string>? Notes { get; set; }
 
         /// <summary>
-        /// This should be either false, true or `move_ip_from:intances_id`.
+        /// This should be either `create`, `none` or `move_ip_from:intances_id`.
         /// </summary>
         [Input("publicIpRequired")]
         public Input<string>? PublicIpRequired { get; set; }
@@ -372,7 +372,7 @@ namespace Pulumi.Civo
         public Input<string>? PublicIp { get; set; }
 
         /// <summary>
-        /// This should be either false, true or `move_ip_from:intances_id`.
+        /// This should be either `create`, `none` or `move_ip_from:intances_id`.
         /// </summary>
         [Input("publicIpRequired")]
         public Input<string>? PublicIpRequired { get; set; }

--- a/sdk/go/civo/instance.go
+++ b/sdk/go/civo/instance.go
@@ -48,7 +48,7 @@ type Instance struct {
 	PseudoIp pulumi.StringOutput `pulumi:"pseudoIp"`
 	// The public ip.
 	PublicIp pulumi.StringOutput `pulumi:"publicIp"`
-	// This should be either false, true or `move_ip_from:intances_id`.
+	// This should be either `create`, `none` or `move_ip_from:intances_id`.
 	PublicIpRequired pulumi.StringPtrOutput `pulumi:"publicIpRequired"`
 	// Total ram of the instance.
 	RamMb pulumi.IntOutput `pulumi:"ramMb"`
@@ -128,7 +128,7 @@ type instanceState struct {
 	PseudoIp *string `pulumi:"pseudoIp"`
 	// The public ip.
 	PublicIp *string `pulumi:"publicIp"`
-	// This should be either false, true or `move_ip_from:intances_id`.
+	// This should be either `create`, `none` or `move_ip_from:intances_id`.
 	PublicIpRequired *string `pulumi:"publicIpRequired"`
 	// Total ram of the instance.
 	RamMb *int `pulumi:"ramMb"`
@@ -177,7 +177,7 @@ type InstanceState struct {
 	PseudoIp pulumi.StringPtrInput
 	// The public ip.
 	PublicIp pulumi.StringPtrInput
-	// This should be either false, true or `move_ip_from:intances_id`.
+	// This should be either `create`, `none` or `move_ip_from:intances_id`.
 	PublicIpRequired pulumi.StringPtrInput
 	// Total ram of the instance.
 	RamMb pulumi.IntPtrInput
@@ -216,7 +216,7 @@ type instanceArgs struct {
 	NetworkId *string `pulumi:"networkId"`
 	// Add some notes to the instance.
 	Notes *string `pulumi:"notes"`
-	// This should be either false, true or `move_ip_from:intances_id`.
+	// This should be either `create`, `none` or `move_ip_from:intances_id`.
 	PublicIpRequired *string `pulumi:"publicIpRequired"`
 	// The region for the instance, if not declare we use the region in declared in the provider.
 	Region *string `pulumi:"region"`
@@ -246,7 +246,7 @@ type InstanceArgs struct {
 	NetworkId pulumi.StringPtrInput
 	// Add some notes to the instance.
 	Notes pulumi.StringPtrInput
-	// This should be either false, true or `move_ip_from:intances_id`.
+	// This should be either `create`, `none` or `move_ip_from:intances_id`.
 	PublicIpRequired pulumi.StringPtrInput
 	// The region for the instance, if not declare we use the region in declared in the provider.
 	Region pulumi.StringPtrInput

--- a/sdk/nodejs/instance.ts
+++ b/sdk/nodejs/instance.ts
@@ -93,7 +93,7 @@ export class Instance extends pulumi.CustomResource {
      */
     public /*out*/ readonly publicIp!: pulumi.Output<string>;
     /**
-     * This should be either false, true or `move_ip_from:intances_id`.
+     * This should be either `create`, `none` or `move_ip_from:intances_id`.
      */
     public readonly publicIpRequired!: pulumi.Output<string | undefined>;
     /**
@@ -262,7 +262,7 @@ export interface InstanceState {
      */
     readonly publicIp?: pulumi.Input<string>;
     /**
-     * This should be either false, true or `move_ip_from:intances_id`.
+     * This should be either `create`, `none` or `move_ip_from:intances_id`.
      */
     readonly publicIpRequired?: pulumi.Input<string>;
     /**
@@ -330,7 +330,7 @@ export interface InstanceArgs {
      */
     readonly notes?: pulumi.Input<string>;
     /**
-     * This should be either false, true or `move_ip_from:intances_id`.
+     * This should be either `create`, `none` or `move_ip_from:intances_id`.
      */
     readonly publicIpRequired?: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_civo/instance.py
+++ b/sdk/python/pulumi_civo/instance.py
@@ -33,7 +33,7 @@ class InstanceArgs:
         :param pulumi.Input[str] initial_user: The name of the initial user created on the server (optional; this will default to the template's default_username and fallback to civo).
         :param pulumi.Input[str] network_id: This must be the ID of the network from the network listing (optional; default network used when not specified).
         :param pulumi.Input[str] notes: Add some notes to the instance.
-        :param pulumi.Input[str] public_ip_required: This should be either false, true or `move_ip_from:intances_id`.
+        :param pulumi.Input[str] public_ip_required: This should be either `create`, `none` or `move_ip_from:intances_id`.
         :param pulumi.Input[str] region: The region for the instance, if not declare we use the region in declared in the provider.
         :param pulumi.Input[str] reverse_dns: A fully qualified domain name that should be used as the instance's IP's reverse DNS (optional, uses the hostname if unspecified).
         :param pulumi.Input[str] script: the contents of a script that will be uploaded to /usr/local/bin/civo-user-init-script on your instance, read/write/executable only by root and then will be executed at the end of the cloud initialization
@@ -132,7 +132,7 @@ class InstanceArgs:
     @pulumi.getter(name="publicIpRequired")
     def public_ip_required(self) -> Optional[pulumi.Input[str]]:
         """
-        This should be either false, true or `move_ip_from:intances_id`.
+        This should be either `create`, `none` or `move_ip_from:intances_id`.
         """
         return pulumi.get(self, "public_ip_required")
 
@@ -266,7 +266,7 @@ class _InstanceState:
         :param pulumi.Input[str] private_ip: The private ip.
         :param pulumi.Input[str] pseudo_ip: Is the ip that is used to route the public ip from the internet to the instance using NAT
         :param pulumi.Input[str] public_ip: The public ip.
-        :param pulumi.Input[str] public_ip_required: This should be either false, true or `move_ip_from:intances_id`.
+        :param pulumi.Input[str] public_ip_required: This should be either `create`, `none` or `move_ip_from:intances_id`.
         :param pulumi.Input[int] ram_mb: Total ram of the instance.
         :param pulumi.Input[str] region: The region for the instance, if not declare we use the region in declared in the provider.
         :param pulumi.Input[str] reverse_dns: A fully qualified domain name that should be used as the instance's IP's reverse DNS (optional, uses the hostname if unspecified).
@@ -474,7 +474,7 @@ class _InstanceState:
     @pulumi.getter(name="publicIpRequired")
     def public_ip_required(self) -> Optional[pulumi.Input[str]]:
         """
-        This should be either false, true or `move_ip_from:intances_id`.
+        This should be either `create`, `none` or `move_ip_from:intances_id`.
         """
         return pulumi.get(self, "public_ip_required")
 
@@ -647,7 +647,7 @@ class Instance(pulumi.CustomResource):
         :param pulumi.Input[str] initial_user: The name of the initial user created on the server (optional; this will default to the template's default_username and fallback to civo).
         :param pulumi.Input[str] network_id: This must be the ID of the network from the network listing (optional; default network used when not specified).
         :param pulumi.Input[str] notes: Add some notes to the instance.
-        :param pulumi.Input[str] public_ip_required: This should be either false, true or `move_ip_from:intances_id`.
+        :param pulumi.Input[str] public_ip_required: This should be either `create`, `none` or `move_ip_from:intances_id`.
         :param pulumi.Input[str] region: The region for the instance, if not declare we use the region in declared in the provider.
         :param pulumi.Input[str] reverse_dns: A fully qualified domain name that should be used as the instance's IP's reverse DNS (optional, uses the hostname if unspecified).
         :param pulumi.Input[str] script: the contents of a script that will be uploaded to /usr/local/bin/civo-user-init-script on your instance, read/write/executable only by root and then will be executed at the end of the cloud initialization
@@ -793,7 +793,7 @@ class Instance(pulumi.CustomResource):
         :param pulumi.Input[str] private_ip: The private ip.
         :param pulumi.Input[str] pseudo_ip: Is the ip that is used to route the public ip from the internet to the instance using NAT
         :param pulumi.Input[str] public_ip: The public ip.
-        :param pulumi.Input[str] public_ip_required: This should be either false, true or `move_ip_from:intances_id`.
+        :param pulumi.Input[str] public_ip_required: This should be either `create`, `none` or `move_ip_from:intances_id`.
         :param pulumi.Input[int] ram_mb: Total ram of the instance.
         :param pulumi.Input[str] region: The region for the instance, if not declare we use the region in declared in the provider.
         :param pulumi.Input[str] reverse_dns: A fully qualified domain name that should be used as the instance's IP's reverse DNS (optional, uses the hostname if unspecified).
@@ -934,7 +934,7 @@ class Instance(pulumi.CustomResource):
     @pulumi.getter(name="publicIpRequired")
     def public_ip_required(self) -> pulumi.Output[Optional[str]]:
         """
-        This should be either false, true or `move_ip_from:intances_id`.
+        This should be either `create`, `none` or `move_ip_from:intances_id`.
         """
         return pulumi.get(self, "public_ip_required")
 


### PR DESCRIPTION
Short fix of the outdated description from the attribute public_ip_requiered to This should be either create, noneormove_ip_from:intances_id`

Maybe this repo gets autogenerated from the Civo TF provider. For this reason i made a PR there too -> https://github.com/civo/terraform-provider-civo/pull/37