### PR TITLE
Use explicit inputs for publish-provider-action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -365,10 +365,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@5c2d53147ccc3308bb3c4872490158a744c1bfd1
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
+        dotnet-version: "6.0.x"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -312,10 +312,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@5c2d53147ccc3308bb3c4872490158a744c1bfd1
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
+        dotnet-version: "6.0.x"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,10 +325,14 @@ jobs:
     - id: version
       uses: pulumi/provider-version-action@v1
     - name: Publish SDKs
-      uses: pulumi/pulumi-package-publisher@v0.0.16
+      uses: pulumi/pulumi-package-publisher@5c2d53147ccc3308bb3c4872490158a744c1bfd1
       with:
         sdk: all
         version: ${{ steps.version.outputs.version }}
+        java-version: "11"
+        node-version: "20.x"
+        python-version: "3.11.8"
+        dotnet-version: "6.0.x"
     - env:
         SLACK_CHANNEL: provider-upgrade-publish-status
         SLACK_COLOR: "#FF0000"


### PR DESCRIPTION
This is a test for https://github.com/pulumi/pulumi-package-publisher/pull/28 in support of resolving https://github.com/pulumi/ci-mgmt/issues/961.

Merging this will not break default any more than it currently is.
